### PR TITLE
Create LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Timi OSS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
### TL;DR

Added MIT License to the project.

### What changed?

Introduced a new LICENSE file containing the full text of the MIT License, attributing the copyright to Timi OSS for the year 2024.

### How to test?

1. Verify that the LICENSE file exists in the root directory of the project.
2. Confirm that the content of the LICENSE file matches the standard MIT License text.
3. Check that the copyright year is set to 2024 and the copyright holder is listed as Timi OSS.

### Why make this change?

Adding a license clarifies the terms under which the software can be used, modified, and distributed. The MIT License is a permissive open-source license that allows for maximum flexibility while still providing basic protections for the copyright holder. This change ensures legal compliance and encourages broader adoption and contribution to the project.